### PR TITLE
консольні команди для дебага

### DIFF
--- a/src/xrEngine/FDemoRecord.cpp
+++ b/src/xrEngine/FDemoRecord.cpp
@@ -405,16 +405,16 @@ void CDemoRecord::IR_OnKeyboardPress	(int dik)
 	if (dik == DIK_F12)		MakeScreenshot			();
 	if (dik == DIK_ESCAPE)	fLifeTime				= -1;
 
-#ifndef MASTER_GOLD
+
 	if (dik == DIK_RETURN)
 	{	
-		if (g_pGameLevel->CurrentEntity())
+		if (g_pGameLevel->CurrentEntity() && strstr(Core.Params, "-dev_mode"))
 		{
 			g_pGameLevel->CurrentEntity()->ForceTransform(m_Camera);
 			fLifeTime		= -1; 
 		}
 	}
-#endif // #ifndef MASTER_GOLD
+
 
 	if	(dik == DIK_PAUSE)		
 		Device.Pause(!Device.Paused(), TRUE, TRUE, "demo_record");

--- a/src/xrGame/Level.cpp
+++ b/src/xrGame/Level.cpp
@@ -50,6 +50,9 @@
 #include "demoinfo.h"
 #include "CustomDetector.h"
 
+#include "../xrEngine/GameMtlLib.h"
+#include "../xrEngine/IGame_Persistent.h"
+
 #include "../xrphysics/iphworld.h"
 #include "../xrphysics/console_vars.h"
 #ifdef DEBUG
@@ -1269,4 +1272,41 @@ CZoneList::~CZoneList()
 {
 	clear();
 	destroy();
+}
+
+ICF static BOOL GetPickDist_Callback(collide::rq_result& result, LPVOID params)
+{
+	collide::rq_result* RQ = (collide::rq_result*)params;
+	if (result.O)
+	{
+		if (Actor())
+		{
+			if (result.O == Actor())
+				return TRUE;
+			if (Actor()->Holder())
+			{
+				CCar* car = smart_cast<CCar*>(Actor()->Holder());
+				if (car && result.0 == car)
+					return TRUE;
+			}
+		}
+	}
+	else
+	{
+		CDB::TRI* T = Level().ObjectSpace.GetStaticTris() + result.element;
+		SGameMtl* pMtl = GMLib.GetMaterialByIdx(T->material);
+		if (pMtl && (pMtl->Flags.is(SGameMtl::flPassable) || pMtl->Flags.is(SGameMtl::flActorObstacle)))
+			return TRUE;
+	}
+	*RQ = result;
+	return FALSE;
+}
+
+collide::rq_result CLevel::GetPickResult(Fvector pos, Fvector die, float range, CObject* ignore)
+{
+	collide::rq_result      RQ; RQ.set(NULL, range, -1);
+	collide::rq_results     RQR;
+	collide::ray_defs       RD(pos, dir, RQ.range, CDB::OPT_FULL_TEST, collide::rqtBoth);
+	Level().ObjectSpace.RayQuery(RQR, RD, GetPickDist_Callback, &RQ, NULL, ignore);
+	return RQ;
 }

--- a/src/xrGame/Level.h
+++ b/src/xrGame/Level.h
@@ -191,6 +191,8 @@ public:
 	CZoneList*					hud_zones_list;
 	CZoneList*					create_hud_zones_list();
 
+	collide::rq_result          GetPickResult(Fvector pos, Fvector dir, float range, CObject* ignore);
+
 private:
 	// preload sounds registry
 	DEFINE_MAP					(shared_str,ref_sound,SoundRegistryMap,SoundRegistryMapIt);


### PR DESCRIPTION
також команди для спавну приймають друге значення для кількості предметів, яких потрібно заспавнити, g_spawn спавнить по напрямку приціла а не під актора. Всі консольні команди доступні лише під ключом -dev_mode. Телепорт на Enter (RETURN) також тепер винесений з-під дефайну та доступний під ключем -developer_mode. Список доданих команд:
g_spawn_to_inv [section] [count]
g_spawn [section] [count]
g_info [info_portion]
d_info [info_portion]
jump_to_level [level_name]
g_god [on/off]
g_unlimitedadmmo [on/off]